### PR TITLE
support sites with omitted protocol portion

### DIFF
--- a/SourceMapX.py
+++ b/SourceMapX.py
@@ -139,8 +139,11 @@ class SourceMapExtractor(object):
                 next_target_uri = source
             else:
                 current_uri = urlparse(uri)
-                built_uri = current_uri.scheme + "://" + current_uri.netloc + source
-                next_target_uri = built_uri
+                if source.startswith('//'):
+                    next_target_uri = current_uri.scheme + ':' + source
+                else:
+                    built_uri = current_uri.scheme + "://" + current_uri.netloc + source
+                    next_target_uri = built_uri
 
             js_data = self._get_remote_data(next_target_uri)
             if js_data:


### PR DESCRIPTION
Some sites omit the protocol portion (http:, https:) from URLs to prevent mixed content issues and result in minor file size savings. Like this:
`<script src="//s1.hdslb.com/bfs/static/jinkela/international-home/1.international-home.a4f08ae57dcc95e7a9ea5ceacc3cefdc9831407a.js" defer=""></script>`